### PR TITLE
Changed serial speed setting

### DIFF
--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
   ],
   "extraIncludes": [],
   "dependencies": {
-    "mbed-drivers": "~0.11.0"
+    "mbed-drivers": "~0.12.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/source/serial_asynch.cpp
+++ b/source/serial_asynch.cpp
@@ -94,16 +94,14 @@ private:
 void app_start(int, char*[]) {
     static SerialTest test;
     // set 115200 baud rate for stdout
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
+    get_stdio_serial().baud(115200);
     Scheduler::postCallback(mbed::util::FunctionPointer0<void>(&test, &SerialTest::start).bind());
 }
 
 #else
 void app_start(int, char*[]) {
     // set 115200 baud rate for stdout
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
+    get_stdio_serial().baud(115200);
     printf("The target does not support Serial asynch API.\r\n");
 }
 #endif


### PR DESCRIPTION
The way to set the serial speed changed starting with mbed-drivers
0.12.0. This commit updates the code to use the new way of setting
the speed.